### PR TITLE
Expose backend service externally

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -15,4 +15,4 @@ CORS(app, resources={
 app.register_blueprint(api, url_prefix='/api')
 
 if __name__ == '__main__':
-    app.run(debug=True, port=3001)  # Match the frontend port
+    app.run(host="0.0.0.0", debug=True, port=3001)  # Match the frontend port


### PR DESCRIPTION
## Summary
- Ensure Flask backend listens on all interfaces by specifying host `0.0.0.0`

## Testing
- `python -m py_compile backend/app.py`
- `docker compose up --build -d` *(fails: unknown flag and Docker daemon unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_68c7a9346e30832e9a47e6b4878967de